### PR TITLE
Prevented Default submit functionality of DateButtons

### DIFF
--- a/example/src/lib/components/Datepicker/CalendarToolbar.js
+++ b/example/src/lib/components/Datepicker/CalendarToolbar.js
@@ -72,13 +72,15 @@ class CalendarToolbar extends Component {
     }
   }
 
-  handleTouchTapPrevMonth = () => {
+  handleTouchTapPrevMonth = e => {
+    e.preventDefault();
     if (this.props.onMonthChange) {
       this.props.onMonthChange(-1);
     }
   };
 
-  handleTouchTapNextMonth = () => {
+  handleTouchTapNextMonth = e => {
+    e.preventDefault();
     if (this.props.onMonthChange) {
       this.props.onMonthChange(1);
     }

--- a/example/src/lib/components/Datepicker/Week.js
+++ b/example/src/lib/components/Datepicker/Week.js
@@ -106,7 +106,8 @@ class Week extends Component {
             return (
               <DayButton
                 key={`day-${day}`}
-                onClick={() => this.onSelect(day)}
+                onClick={(e) => {e.preventDefault();
+                this.onSelect(day)}
                 disabled={isDisabled}
                 selected={isSelected}
               >

--- a/example/src/lib/components/Datepicker/index.js
+++ b/example/src/lib/components/Datepicker/index.js
@@ -111,6 +111,7 @@ class DatePicker extends Component {
   };
 
   handleOk = () => {
+    e.preventDefault();
     if (this.props.onSubmit) {
       this.props.onSubmit(this.state.selectedDates);
     }

--- a/example/src/lib/components/Datepicker/index.js
+++ b/example/src/lib/components/Datepicker/index.js
@@ -102,7 +102,8 @@ class DatePicker extends Component {
     this.setState({ open: !this.state.open });
   };
 
-  handleCancel = () => {
+  handleCancel = (e) => {
+    e.preventDefault()
     this.dismiss();
   };
 

--- a/example/src/lib/components/Datepicker/index.js
+++ b/example/src/lib/components/Datepicker/index.js
@@ -110,7 +110,7 @@ class DatePicker extends Component {
     this.dismiss();
   };
 
-  handleOk = () => {
+  handleOk = (e) => {
     e.preventDefault();
     if (this.props.onSubmit) {
       this.props.onSubmit(this.state.selectedDates);


### PR DESCRIPTION
When used in a `Form`, the selection of dates used to submit the form automatically. [Here's the example](https://codesandbox.io/s/5w31rvpmll). In the commit, I prevented the default functionality of DayButton and onSelect.